### PR TITLE
 Fix HTTP User-Agent string format

### DIFF
--- a/public/app/js/cbus-const.js
+++ b/public/app/js/cbus-const.js
@@ -12,7 +12,7 @@ cbus.const.podcastSort = function(a, b) {
 };
 
 cbus.const.REQUEST_HEADERS = {
-  "User-Agent": `CPod v${package.version} (github.com/z-------------)`
+  "User-Agent": `CPod/${package.version} (github.com/z-------------)`
 };
 cbus.const.REQUEST_TIMEOUT = 15 * 1000;
 


### PR DESCRIPTION
The expected format is Component/Component-Version (Component-Attribute1; Component-Attribute2).

Spaces separate multiple components.