### PR TITLE
Add volume slider to player toggles

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -146,6 +146,8 @@
   "label_keyboard-shortcuts_action_next": "Weiter",
   "label_keyboard-shortcuts_action_speed-increase": "Wiedergabegeschwindigkeit erhöhen",
   "label_keyboard-shortcuts_action_speed-decrease": "Wiedergabegeschwindigkeit verringern",
+  "label_keyboard-shortcuts_action_volume-increase": "",
+  "label_keyboard-shortcuts_action_volume-decrease": "",
   "settings_keyboard-shortcuts_help": "Verwendet die Mousetrap-Syntax",
 
   "text_contributors": "Mitwirkende: ",

--- a/locales/de.json
+++ b/locales/de.json
@@ -111,6 +111,7 @@
   "button_playback-next": "Weiter",
 
   "label_playback-speed": "Wiedergabegeschwindigkeit",
+  "label_volume": "",
   "label_search-results": "Suchergebnisse",
   "label_app-updates": "Aktualisierungen",
   "label_download-prereleases": "Vorabversionen beim automatischen Update erlauben",

--- a/locales/en.json
+++ b/locales/en.json
@@ -111,6 +111,7 @@
   "button_playback-next": "Next",
 
   "label_playback-speed": "Playback speed",
+  "label_volume": "Volume",
   "label_search-results": "Search results",
   "label_app-updates": "Updates",
   "label_download-prereleases": "Allow pre-releases when auto-updating",

--- a/locales/en.json
+++ b/locales/en.json
@@ -146,6 +146,8 @@
   "label_keyboard-shortcuts_action_next": "Next",
   "label_keyboard-shortcuts_action_speed-increase": "Playback speed increase",
   "label_keyboard-shortcuts_action_speed-decrease": "Playback speed decrease",
+  "label_keyboard-shortcuts_action_volume-increase": "Playback volume increase",
+  "label_keyboard-shortcuts_action_volume-decrease": "Playback volume decrease",
   "settings_keyboard-shortcuts_help": "Uses Mousetrap syntax",
 
   "text_contributors": "Contributors: ",

--- a/locales/es.json
+++ b/locales/es.json
@@ -111,6 +111,7 @@
   "button_playback-next": "",
 
   "label_playback-speed": "Tasa de reproducción",
+  "label_volume": "",
   "label_search-results": "Resultados de la búsqueda",
   "label_app-updates": "",
   "label_download-prereleases": "",

--- a/locales/es.json
+++ b/locales/es.json
@@ -146,6 +146,8 @@
   "label_keyboard-shortcuts_action_next": "",
   "label_keyboard-shortcuts_action_speed-increase": "",
   "label_keyboard-shortcuts_action_speed-decrease": "",
+  "label_keyboard-shortcuts_action_volume-increase": "",
+  "label_keyboard-shortcuts_action_volume-decrease": "",
   "settings_keyboard-shortcuts_help": "",
 
   "text_contributors": "",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -111,6 +111,7 @@
   "button_playback-next": "Suivant",
 
   "label_playback-speed": "Vitesse de lecture",
+  "label_volume": "",
   "label_search-results": "Résultat de la recherche",
   "label_app-updates": "",
   "label_download-prereleases": "",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -146,6 +146,8 @@
   "label_keyboard-shortcuts_action_next": "",
   "label_keyboard-shortcuts_action_speed-increase": "",
   "label_keyboard-shortcuts_action_speed-decrease": "",
+  "label_keyboard-shortcuts_action_volume-increase": "",
+  "label_keyboard-shortcuts_action_volume-decrease": "",
   "settings_keyboard-shortcuts_help": "",
 
   "text_contributors": "",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -111,6 +111,7 @@
   "button_playback-next": "",
 
   "label_playback-speed": "재생 속도",
+  "label_volume": "",
   "label_search-results": "검색 결과",
   "label_app-updates": "",
   "label_download-prereleases": "",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -146,6 +146,8 @@
   "label_keyboard-shortcuts_action_next": "",
   "label_keyboard-shortcuts_action_speed-increase": "",
   "label_keyboard-shortcuts_action_speed-decrease": "",
+  "label_keyboard-shortcuts_action_volume-increase": "",
+  "label_keyboard-shortcuts_action_volume-decrease": "",
   "settings_keyboard-shortcuts_help": "",
 
   "text_contributors": "",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -146,6 +146,8 @@
   "label_keyboard-shortcuts_action_next": "Volgende",
   "label_keyboard-shortcuts_action_speed-increase": "Afspeelsnelheid verhogen",
   "label_keyboard-shortcuts_action_speed-decrease": "Afspeelsnelheid verminderen",
+  "label_keyboard-shortcuts_action_volume-increase": "",
+  "label_keyboard-shortcuts_action_volume-decrease": "",
   "settings_keyboard-shortcuts_help": "Gebruikt de ‘Mousetrap syntax’",
 
   "text_contributors": "Gemaakt door ",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -111,6 +111,7 @@
   "button_playback-next": "Volgende",
 
   "label_playback-speed": "Afspeelsnelheid",
+  "label_volume": "",
   "label_search-results": "Zoekresultaten",
   "label_app-updates": "Updates",
   "label_download-prereleases": "Sta ‘pre-releases’ toe bij automatisch updaten",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -146,6 +146,8 @@
   "label_keyboard-shortcuts_action_next": "Seguinte",
   "label_keyboard-shortcuts_action_speed-increase": "Aumentar  velocidade de reprodução",
   "label_keyboard-shortcuts_action_speed-decrease": "Diminuir velocidade de reprodução",
+  "label_keyboard-shortcuts_action_volume-increase": "",
+  "label_keyboard-shortcuts_action_volume-decrease": "",
   "settings_keyboard-shortcuts_help": "Utiliza a sintaxe Mousetrap",
 
   "text_contributors": "Colaboradores: ",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -111,6 +111,7 @@
   "button_playback-next": "Seguinte",
 
   "label_playback-speed": "Velocidade de reprodução",
+  "label_volume": "",
   "label_search-results": "Resultados da pesquisa",
   "label_app-updates": "Atualizações",
   "label_download-prereleases": "Permitir atualização automática das versões de teste",

--- a/locales/pt_BR.json
+++ b/locales/pt_BR.json
@@ -146,6 +146,8 @@
   "label_keyboard-shortcuts_action_next": "Seguinte",
   "label_keyboard-shortcuts_action_speed-increase": "",
   "label_keyboard-shortcuts_action_speed-decrease": "",
+  "label_keyboard-shortcuts_action_volume-increase": "",
+  "label_keyboard-shortcuts_action_volume-decrease": "",
   "settings_keyboard-shortcuts_help": "Utiliza a sintaxe Mousetrap",
 
   "text_contributors": "Quem contribuiu: ",

--- a/locales/pt_BR.json
+++ b/locales/pt_BR.json
@@ -111,6 +111,7 @@
   "button_playback-next": "Próximo",
 
   "label_playback-speed": "Velocidade de reprodução",
+  "label_volume": "",
   "label_search-results": "Resultados da pesquisa",
   "label_app-updates": "Atualizações",
   "label_download-prereleases": "Permitir atualização automática das versões de teste",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -111,6 +111,7 @@
   "button_playback-next": "Далі",
 
   "label_playback-speed": "Швидкість відтворення",
+  "label_volume": "",
   "label_search-results": "Результати пошуку",
   "label_app-updates": "Оновлення",
   "label_download-prereleases": "Дозволити попередні випуски під час автоматичного оновлення",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -146,6 +146,8 @@
   "label_keyboard-shortcuts_action_next": "Далі",
   "label_keyboard-shortcuts_action_speed-increase": "Збільшити швидкість відтворення",
   "label_keyboard-shortcuts_action_speed-decrease": "Зменшити швидкість відтворення",
+  "label_keyboard-shortcuts_action_volume-increase": "",
+  "label_keyboard-shortcuts_action_volume-decrease": "",
   "settings_keyboard-shortcuts_help": "Використання синтаксису Mousetrap",
 
   "text_contributors": "Автори: ",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -146,6 +146,8 @@
   "label_keyboard-shortcuts_action_next": "",
   "label_keyboard-shortcuts_action_speed-increase": "",
   "label_keyboard-shortcuts_action_speed-decrease": "",
+  "label_keyboard-shortcuts_action_volume-increase": "",
+  "label_keyboard-shortcuts_action_volume-decrease": "",
   "settings_keyboard-shortcuts_help": "",
 
   "text_contributors": "",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -111,6 +111,7 @@
   "button_playback-next": "",
 
   "label_playback-speed": "播放速度",
+  "label_volume": "",
   "label_search-results": "搜索结果",
   "label_app-updates": "",
   "label_download-prereleases": "",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -146,6 +146,8 @@
   "label_keyboard-shortcuts_action_next": "",
   "label_keyboard-shortcuts_action_speed-increase": "",
   "label_keyboard-shortcuts_action_speed-decrease": "",
+  "label_keyboard-shortcuts_action_volume-increase": "",
+  "label_keyboard-shortcuts_action_volume-decrease": "",
   "settings_keyboard-shortcuts_help": "",
 
   "text_contributors": "",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -111,6 +111,7 @@
   "button_playback-next": "",
 
   "label_playback-speed": "播放速度",
+  "label_volume": "",
   "label_search-results": "搜索結果",
   "label_app-updates": "",
   "label_download-prereleases": "",

--- a/public/app/index.pug
+++ b/public/app/index.pug
@@ -321,9 +321,14 @@ html
         p.firstrun_howto_subscriptions(data-i18n-name="welcome_howto_subscriptions").i18n
     
     .player-toggles
-      label
-        span(data-i18n-name="label_playback-speed").i18n
-        input.player-toggles_speed(type="number", min="0.5", max="4", step="0.1", value="1")
+      p
+        label
+          span(data-i18n-name="label_playback-speed").i18n
+          input.player-toggles_speed(type="number", min="0.5", max="4", step="0.1", value="1")
+      p
+        label
+          span(data-i18n-name="label_volume").i18n
+          input.player-toggles_volume_slider(type="range", min="0", max="100", value="100")
 
     .audios
 

--- a/public/app/index.pug
+++ b/public/app/index.pug
@@ -117,7 +117,7 @@ html
               span(data-i18n-name="label_global_media_keys").i18n
             .settings_label_right
               input(type="checkbox", data-setting-key="globalMediaKeysEnable", data-setting-needrestart)
-          div(data-setting-key="keyboardShortcuts", data-setting-type="mapping", data-setting-needrestart, data-setting-valueoptions="playpause;skip-backward-short;skip-backward;skip-backward-long;skip-forward-short;skip-forward;skip-forward-long;next;speed-increase;speed-decrease")
+          div(data-setting-key="keyboardShortcuts", data-setting-type="mapping", data-setting-needrestart, data-setting-valueoptions="playpause;skip-backward-short;skip-backward;skip-backward-long;skip-forward-short;skip-forward;skip-forward-long;next;speed-increase;speed-decrease;volume-increase;volume-decrease")
             //- elements added by script
           p.settings_help(data-i18n-name="settings_keyboard-shortcuts_help").i18n
         .settings_section
@@ -328,7 +328,7 @@ html
       p
         label
           span(data-i18n-name="label_volume").i18n
-          input.player-toggles_volume_slider(type="range", min="0", max="100", value="100")
+          input.player-toggles_volume_slider(type="range", min="0", max="1", step="0.01", value="1")
 
     .audios
 

--- a/public/app/js/cbus-audio.js
+++ b/public/app/js/cbus-audio.js
@@ -24,6 +24,7 @@ cbus.audio = {
 
   setElement: function(elem, disableAutomaticProgressRestore) {
     var prevPlaybackRate;
+    var prevVolume;
 
     if (cbus.audio.element) {
       cbus.audio.pause();
@@ -34,12 +35,14 @@ cbus.audio = {
       cbus.audio.element.onended = null;
 
       prevPlaybackRate = cbus.audio.element.playbackRate;
+      prevVolume = cbus.audio.element.volume;
     }
 
     cbus.audio.element = elem;
 
     if (prevPlaybackRate) {
       cbus.audio.element.playbackRate = prevPlaybackRate;
+      cbus.audio.element.volume = prevVolume
     }
 
     if (disableAutomaticProgressRestore === true) {
@@ -252,6 +255,11 @@ cbus.audio = {
       cbus.audio.mprisPlayer.rate = cbus.audio.element.playbackRate;
     }
     cbus.broadcast.send("playbackRateChanged", cbus.audio.element.playbackRate);
+  },
+  setVolume: function(volume) {
+    cbus.audio.element.volume = volume / 100;
+
+    // TODO send broadcast after adding keyboard shortcut
   },
 
   queue: [],

--- a/public/app/js/cbus-audio.js
+++ b/public/app/js/cbus-audio.js
@@ -258,7 +258,9 @@ cbus.audio = {
   },
   setVolume: function(volume) {
     cbus.audio.element.volume = volume / 100;
-
+    if (cbus.audio.mprisPlayer) {
+      cbus.audio.mprisPlayer.volume = cbus.audio.element.volume
+    }
     // TODO send broadcast after adding keyboard shortcut
   },
 

--- a/public/app/js/cbus-audio.js
+++ b/public/app/js/cbus-audio.js
@@ -257,11 +257,11 @@ cbus.audio = {
     cbus.broadcast.send("playbackRateChanged", cbus.audio.element.playbackRate);
   },
   setVolume: function(volume) {
-    cbus.audio.element.volume = volume / 100;
+    cbus.audio.element.volume = clamp(volume, 0, 1);
     if (cbus.audio.mprisPlayer) {
-      cbus.audio.mprisPlayer.volume = cbus.audio.element.volume
+      cbus.audio.mprisPlayer.volume = cbus.audio.element.volume;
     }
-    // TODO send broadcast after adding keyboard shortcut
+    cbus.broadcast.send("volumeChanged", cbus.audio.element.volume);
   },
 
   queue: [],
@@ -349,7 +349,7 @@ if (MPRISPlayer) {
   });
   cbus.audio.mprisPlayer.on("volume", (data) => {
     if (cbus.audio.element) {
-      cbus.audio.element.volume = clamp(data.volume, 0, 1);
+      cbus.audio.setVolume(data.volume);
     }
   });
   cbus.audio.mprisPlayer.on("rate", (data) => {

--- a/public/app/js/cbus-broadcast.js
+++ b/public/app/js/cbus-broadcast.js
@@ -7,7 +7,7 @@ cbus.broadcast.send = function(name, data) {
         if (cbus.broadcast.listeners[i].name === name) {
             cbus.broadcast.listeners[i].callback({
                 name: name,
-                data: data || {}
+                data: data
             });
         }
     }

--- a/public/app/js/cbus-ui.js
+++ b/public/app/js/cbus-ui.js
@@ -1491,6 +1491,9 @@ tippy(".header_nav a", {
     if (e.target.classList.contains("player-toggles_speed")) {
       cbus.audio.setPlaybackRate(Number(e.target.value));
     }
+    if (e.target.classList.contains("player-toggles_volume_slider")) {
+      cbus.audio.setVolume(Number(e.target.value));
+    }
   });
 
   playerTogglesElem.addEventListener("change", (e) => {
@@ -1611,6 +1614,7 @@ for (let keyboardShortcut in cbus.settings.data.keyboardShortcuts) {
       action = function() {
         cbus.audio.setPlaybackRate(round(cbus.audio.element.playbackRate - 0.1, 0.1));
       };
+    // TODO add volume keyboardshortcut
       break;
   }
   Mousetrap.bind(keyboardShortcut, action);

--- a/public/app/style.scss
+++ b/public/app/style.scss
@@ -1169,6 +1169,33 @@ header {
     padding: 0 0.3em;
     width: 3.5em;
   }
+  p {
+    text-align: right;
+    margin-bottom: 0.5em;
+  }
+  .player-toggles_volume_slider {
+    width: calc(100% - 100px);
+    background: transparent;
+
+    -webkit-appearance: none;
+    
+    &::-webkit-slider-runnable-track {
+      -webkit-appearance: none;
+      height: 3px;
+      background-color: var(--color-player-slider-track);
+      cursor: pointer;
+    }
+
+    &::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      width: 15px;
+      height: 15px;
+      border-radius: 50%;
+      background-color: var(--color-player-text);
+      margin-top: -6px;
+      cursor: pointer;
+    }
+  }
 }
 
 .black-bg {


### PR DESCRIPTION
Implemented the feature request from #147 

### Additions
- Adds a volume slider with similar style to main slider below Playback speed input under player-toggles menu in `index.pug`
- Similar to playback speed previous settings persist between podcasts.
- Finally, handles [mprisPlayer](https://www.npmjs.com/package/mpris-service) similar to other handlers but, I am not sure if that is necessary. I don't understand why it is being checked.
### TODO
- Adds translation for en.json. Any help is appreciated for others. If it is okay, I can translate and add to other locales as well.
- Also added TODO for adding keyboard shortcut handlers for volume change. I can add those as well.
<img width="847" alt="Screen Shot 2019-05-31 at 23 04 16" src="https://user-images.githubusercontent.com/10602289/58743038-720b9300-83f8-11e9-8db7-3b81e6a8e987.png">

If you want me to add anything, I am happy to.