### PR TITLE
Fix error on downloads directory browse cancel

### DIFF
--- a/public/app/js/cbus-ui.js
+++ b/public/app/js/cbus-ui.js
@@ -1136,11 +1136,13 @@ document.getElementById("settingDownloadDirectoryBrowseButton").addEventListener
     defaultPath: cbus.settings.data.downloadDirectory,
     properties: [ "openDirectory", "createDirectory" ]
   }, filePaths => {
-    let settingElem = document.querySelector("[data-setting-key=downloadDirectory]");
-    settingElem.value = filePaths[0];
-    let changeEvent = document.createEvent("HTMLEvents");
-    changeEvent.initEvent("change", false, true);
-    settingElem.dispatchEvent(changeEvent);
+    if (filePaths) {
+      let settingElem = document.querySelector("[data-setting-key=downloadDirectory]");
+      settingElem.value = filePaths[0];
+      let changeEvent = document.createEvent("HTMLEvents");
+      changeEvent.initEvent("change", false, true);
+      settingElem.dispatchEvent(changeEvent);
+    }
   });
 });
 


### PR DESCRIPTION
Fixes the issue #149.

It checks if filePaths is truthy before making changes to the settings.