### PR TITLE
Duplicated episodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CPod",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "A simple, beautiful podcast app.",
   "main": "main.js",
   "scripts": {

--- a/public/app/js/cbus-audio.js
+++ b/public/app/js/cbus-audio.js
@@ -297,7 +297,6 @@ cbus.audio = {
       "xesam:artist": [ cbus.audio.state.feed.title ]
     };
     cbus.audio.mprisPlayer.position = cbus.audio.element.currentTime * 1000000;
-    console.log("metadata set", cbus.audio.mprisPlayer.metadata)
   }
 };
 

--- a/public/app/js/cbus-audio.js
+++ b/public/app/js/cbus-audio.js
@@ -109,8 +109,8 @@ cbus.audio = {
               }
             }
             for (let i = currentIndex + 1; i < l; i++) {
-              if (!cbus.data.getEpisodeProgress(cbus.data.episodes[i].url).completed) {
-                cbus.audio.setElement(getElem(".audios").querySelector(`[data-id="${cbus.data.episodes[i].url}"]`));
+              if (!cbus.data.getEpisodeProgress(cbus.data.episodes[i].id).completed) {
+                cbus.audio.setElement(getElem(".audios").querySelector(`[data-id="${cbus.data.episodes[i].id}"]`));
                 cbus.audio.play();
                 break;
               }
@@ -147,7 +147,7 @@ cbus.audio = {
     cbus.broadcast.send("audioChange", cbus.audio.state.episode);
     cbus.ui.updateThumbarButtons();
 
-    localforage.setItem("cbus-last-audio-url", elem.dataset.id);
+    localforage.setItem("cbus-last-audio-url", elem.dataset.id); // TODO rename cbus-last-data-id?
 
     cbus.audio.updatePlayerTime();
   },

--- a/public/app/js/cbus-data.js
+++ b/public/app/js/cbus-data.js
@@ -50,10 +50,6 @@ cbus.data.update = function(specificFeedData, untilLastDisplayedEpisode, cb) {
         if (!isDuplicate) { // not a duplicate
           let episodeDate = new Date(episode.date);
 
-	  console.log("Episode non-duplicate: " + episode.url + " date: " + episodeDate); 
-	  console.log("Episode title: ", episode.title);
-	  console.log("Episode description: ", episode.description);
-	  console.log("Episode id: ", episode.id);
           cbus.data.episodes.unshift({
             id: episode.id,
             url: episode.url,

--- a/public/app/js/cbus-data.js
+++ b/public/app/js/cbus-data.js
@@ -100,7 +100,7 @@ cbus.data.makeMediaElem = function(episodeInfo) {
   if (cbus.data.episodesOffline.indexOf(episodeInfo.id) === -1) {
     elem.src = episodeInfo.url;
   } else {
-    elem.src = fileUrl(cbus.data.getEpisodeDownloadedPath(episodeInfo.url, episodeInfo.id));
+    elem.src = fileUrl(cbus.data.getEpisodeDownloadedPath(episodeInfo.id));
   }
   elem.dataset.id = episodeInfo.id;
   elem.preload = "none";
@@ -472,7 +472,7 @@ cbus.data.downloadEpisode = function(audioElem) {
       // intervalID will be added upon stream open
     };
   } else if (cbus.data.episodesOffline.indexOf(episodeId) !== -1) { // downloaded, so remove download
-    let downloadedPath = cbus.data.getEpisodeDownloadedPath(audioURL, episodeId);
+    let downloadedPath = cbus.data.getEpisodeDownloadedPath(episodeId);
     fs.unlink(downloadedPath, function(err) {
       if (err) {
         cbus.ui.showSnackbar(i18n.__("dialog_download-remove-error_title"), "error");
@@ -589,7 +589,7 @@ cbus.data.getPodcastImageURI = function(feed) {
   return null;
 };
 
-cbus.data.getEpisodeDownloadedPath = function(url, id, options) {
+cbus.data.getEpisodeDownloadedPath = function(id, options) {
   options = options || {};
   if (cbus.data.episodesOfflineMap.hasOwnProperty(id)) { // new-style; includes file extension
     if (options.filenameOnly) {
@@ -604,10 +604,10 @@ cbus.data.getEpisodeDownloadedPath = function(url, id, options) {
     // for episodes downloaded using the old system.
     // episodesOffline contains all downloaded eps., episodesOfflineMap only the new ones.
     if (options.filenameOnly) {
-      return sha1(url);
+      return sha1(id);
     } else {
       return path.join(
-        cbus.settings.data.downloadDirectory, sha1(url)
+        cbus.settings.data.downloadDirectory, sha1(id)
       );
     }
   }
@@ -875,7 +875,7 @@ cbus.broadcast.listen("offline_episodes_changed", function(info) {
     let prevPlaybackRate = audioElem.playbackRate;
 
     if (cbus.data.episodesOffline.indexOf(episodeId) !== -1) { // added to offline episodes
-      audioElem.src = fileUrl(cbus.data.getEpisodeDownloadedPath(episodeURL, episodeId));
+      audioElem.src = fileUrl(cbus.data.getEpisodeDownloadedPath(episodeId));
     } else { // removed from offline episodes
       if (audioElem === cbus.audio.element) { // if currently being played
         cbus.audio.pause();
@@ -956,9 +956,8 @@ cbus.broadcast.listen("settingChanged", e => {
       let mediasElem = getElem(".audios");
       for (let id of cbus.data.episodesOffline) {
         let elem = mediasElem.querySelector(`[data-id="${id}"]`);
-        let episodeData = cbus.data.getEpisodeData({ id });
-        if (elem && episodeData) {
-          elem.src = fileUrl(cbus.data.getEpisodeDownloadedPath(episodeData.url, id));
+        if (elem) {
+          elem.src = fileUrl(cbus.data.getEpisodeDownloadedPath(id));
         }
       }
 

--- a/public/app/js/cbus-data.js
+++ b/public/app/js/cbus-data.js
@@ -956,9 +956,9 @@ cbus.broadcast.listen("settingChanged", e => {
       let mediasElem = getElem(".audios");
       for (let id of cbus.data.episodesOffline) {
         let elem = mediasElem.querySelector(`[data-id="${id}"]`);
-        if (elem) {
-          // TODO need URL, if not elem.url, then episodesOfflineMap?
-          elem.src = fileUrl(cbus.data.getEpisodeDownloadedPath(elem.url, id));
+        let episodeData = cbus.data.getEpisodeData({ id });
+        if (elem && episodeData) {
+          elem.src = fileUrl(cbus.data.getEpisodeDownloadedPath(episodeData.url, id));
         }
       }
 

--- a/public/app/js/cbus-data.js
+++ b/public/app/js/cbus-data.js
@@ -310,7 +310,7 @@ cbus.data.unsubscribeFeed = function(options, showModal, isFromSync) {
 
     if (feedExists) {
       let data = arraysFindByKeySingle([cbus.data.feeds, cbus.data.feedsCache], key, options[key]);
-      let episodeURLs = cbus.data.episodes.filter(episode => episode.feedURL === data.url).map(episode => episode.url);
+      let episodeIds = cbus.data.episodes.filter(episode => episode.feedURL === data.url).map(episode => episode.id);
 
       // remove from feeds list
       cbus.data.feeds.splice(feedIndex, 1);
@@ -325,8 +325,8 @@ cbus.data.unsubscribeFeed = function(options, showModal, isFromSync) {
 
       // remove from episodes list, add to episodesUnsubbed if in queue or now playing
       for (let i = 0, l = cbus.data.episodes.length; i < l; i++) {
-        if (episodeURLs.indexOf(cbus.data.episodes[i].url) !== -1) {
-          if (cbus.audio.element.src === episodeURLs[i] || cbus.audio.queue.map(elem => elem.src).indexOf(episodeURLs[i]) !== -1) {
+        if (episodeIds.indexOf(cbus.data.episodes[i].id) !== -1) {
+          if (cbus.audio.element.dataset.id === episodeIds[i] || cbus.audio.queue.map(elem => elem.dataset.id).indexOf(episodeIds[i]) !== -1) {
             cbus.data.episodesUnsubbed.push(cbus.data.episodes[i]);
           }
           cbus.data.episodes.splice(i, 1);
@@ -337,8 +337,8 @@ cbus.data.unsubscribeFeed = function(options, showModal, isFromSync) {
 
       // remove episode elements from Home list
       let homeListElem = document.getElementById("stream").getElementsByClassName("list--episodes")[0];
-      for (let i = 0, l = episodeURLs.length; i < l; i++) {
-        let elemToRemove = homeListElem.querySelector(`[data-id="${episodeURLs[i]}"]`); // TODO should be episodeId
+      for (let i = 0, l = episodeIds.length; i < l; i++) {
+        let elemToRemove = homeListElem.querySelector(`[data-id="${episodeIds[i]}"]`);
         if (elemToRemove) homeListElem.removeChild(elemToRemove);
       }
 

--- a/public/app/js/cbus-data.js
+++ b/public/app/js/cbus-data.js
@@ -41,7 +41,7 @@ cbus.data.update = function(specificFeedData, untilLastDisplayedEpisode, cb) {
         /* check whether is duplicate */
         var isDuplicate = false;
         for (let k = 0, n = cbus.data.episodes.length; k < n; k++) {
-	  /* comparing the id should be sufficient, but to handle previous versions storing the url as the id, we test the url match too */
+          /* comparing the id should be sufficient, but to handle previous versions storing the url as the id, we test the url match too */
           if (cbus.data.episodes[k].id === episode.id || cbus.data.episodes[k].url === episode.url) {
             isDuplicate = true
             break;
@@ -387,7 +387,7 @@ cbus.data.downloadEpisode = function(audioElem) {
   let feedData = cbus.data.getFeedData({ url: episodeData.feedURL });
   let audioURL = episodeData.url;
   let episodeId = episodeData.id;
-  
+
   var fileExtension = "";
   let audioURLSplit = audioURL.split(".");
   if (audioURLSplit[audioURLSplit.length - 1].length <= 5) {
@@ -447,7 +447,7 @@ cbus.data.downloadEpisode = function(audioElem) {
 
         cbus.broadcast.send("offline_episodes_changed", {
           episodeURL: audioURL,
-	  episodeId: episodeId
+          episodeId: episodeId
         });
       }
     });
@@ -492,7 +492,7 @@ cbus.data.downloadEpisode = function(audioElem) {
         )
         cbus.broadcast.send("offline_episodes_changed", {
           episodeURL: audioURL,
-	  episodeId: episodeId
+          episodeId: episodeId
         });
       }
     })
@@ -957,7 +957,7 @@ cbus.broadcast.listen("settingChanged", e => {
       for (let id of cbus.data.episodesOffline) {
         let elem = mediasElem.querySelector(`[data-id="${id}"]`);
         if (elem) {
-	  // TODO need URL, if not elem.url, then episodesOfflineMap?
+          // TODO need URL, if not elem.url, then episodesOfflineMap?
           elem.src = fileUrl(cbus.data.getEpisodeDownloadedPath(elem.url, id));
         }
       }

--- a/public/app/js/cbus-data.js
+++ b/public/app/js/cbus-data.js
@@ -32,6 +32,7 @@ cbus.data.update = function(specificFeedData, untilLastDisplayedEpisode, cb) {
     for (let i = 0, l = feedContentsKeys.length; i < l; i++) {
       let feedUrl = feedContentsKeys[i];
 
+      console.log("Server update " + feedUrl);
       let feed = cbus.data.getFeedData({ url: feedUrl });
 
       for (let j = 0, m = feedContents[feedUrl].items.length; j < m; j++) {
@@ -40,7 +41,8 @@ cbus.data.update = function(specificFeedData, untilLastDisplayedEpisode, cb) {
         /* check whether is duplicate */
         var isDuplicate = false;
         for (let k = 0, n = cbus.data.episodes.length; k < n; k++) {
-          if (cbus.data.episodes[k].url === episode.url) {
+	  /* comparing the id should be sufficient, but to handle previous versions storing the url as the id, we test the url match too */
+          if (cbus.data.episodes[k].id === episode.id || cbus.data.episodes[k].url === episode.url) {
             isDuplicate = true
             break;
           }
@@ -48,6 +50,10 @@ cbus.data.update = function(specificFeedData, untilLastDisplayedEpisode, cb) {
         if (!isDuplicate) { // not a duplicate
           let episodeDate = new Date(episode.date);
 
+	  console.log("Episode non-duplicate: " + episode.url + " date: " + episodeDate); 
+	  console.log("Episode title: ", episode.title);
+	  console.log("Episode description: ", episode.description);
+	  console.log("Episode id: ", episode.id);
           cbus.data.episodes.unshift({
             id: episode.id,
             url: episode.url,
@@ -773,7 +779,7 @@ cbus.broadcast.listen("updateFeedArtworks", function(e) {
   var doneCount = 0;
   var start = 0, end = cbus.data.feeds.length;
 
-  if (e.data.feedUrl) {
+  if (e.data && e.data.feedUrl) {
     for (let i = 0, l = cbus.data.feeds.length; i < l; i++) {
       if (cbus.data.feeds[i].url === e.data.feedUrl) {
         start = i;

--- a/public/app/js/cbus-server-update.js
+++ b/public/app/js/cbus-server-update.js
@@ -99,9 +99,10 @@ if (!cbus.hasOwnProperty("server")) { cbus.server = {} }
                   var description = null;
                   let summaryElem = item.getElementsByTagName("itunes:summary")[0];
                   let descriptionElem = item.getElementsByTagName("description")[0];
-                  if (summaryElem) {
+		  /* ensure the summary is populated, and not just empty */
+                  if (summaryElem && summaryElem.textContent) {
                     description = summaryElem.textContent;
-                  } else if (descriptionElem) {
+                  } else if (descriptionElem && descriptionElem.textContent) {
                     description = descriptionElem.textContent;
                   }
                   if (description) { episodeInfo.description = description; }

--- a/public/app/js/cbus-server-update.js
+++ b/public/app/js/cbus-server-update.js
@@ -88,7 +88,7 @@ if (!cbus.hasOwnProperty("server")) { cbus.server = {} }
                   }
                   episodeInfo.url = mediaInfo.url;
 
-		  /* episode id: in the absence of a <guid> element, use the media URL */
+                  /* episode id: in the absence of a <guid> element, use the media URL */
                   episodeInfo.id = mediaInfo.url;
                   let childrenGUID = [].slice.call(item.children).filter(child => child.tagName.toLowerCase() === "guid");
                   if (childrenGUID[0]) {
@@ -99,7 +99,7 @@ if (!cbus.hasOwnProperty("server")) { cbus.server = {} }
                   var description = null;
                   let summaryElem = item.getElementsByTagName("itunes:summary")[0];
                   let descriptionElem = item.getElementsByTagName("description")[0];
-		  /* ensure the summary is populated, and not just empty */
+                  /* ensure the summary is populated, and not just empty */
                   if (summaryElem && summaryElem.textContent) {
                     description = summaryElem.textContent;
                   } else if (descriptionElem && descriptionElem.textContent) {

--- a/public/app/js/cbus-server-update.js
+++ b/public/app/js/cbus-server-update.js
@@ -87,7 +87,13 @@ if (!cbus.hasOwnProperty("server")) { cbus.server = {} }
                     episodeInfo.isVideo = false;
                   }
                   episodeInfo.url = mediaInfo.url;
+
+		  /* episode id: in the absence of a <guid> element, use the media URL */
                   episodeInfo.id = mediaInfo.url;
+                  let childrenGUID = [].slice.call(item.children).filter(child => child.tagName.toLowerCase() === "guid");
+                  if (childrenGUID[0]) {
+                    episodeInfo.id = childrenGUID[0].textContent;
+                  } 
 
                   /* episode description */
                   var description = null;

--- a/public/app/js/cbus-ui.js
+++ b/public/app/js/cbus-ui.js
@@ -836,7 +836,7 @@ cbus.broadcast.listen("gotPodcastData", function(e) {
   });
 
   document.querySelector(".podcast-detail_control--mark-all-played").onclick = function() {
-    let episodeIDs = arrayFindByKey(cbus.data.episodes, "feedURL", feedData.url).map(episode => episode.url); // TODO episode.id?
+    let episodeIDs = arrayFindByKey(cbus.data.episodes, "feedURL", feedData.url).map(episode => episode.id);
     cbus.data.batchMarkAsPlayed(episodeIDs);
   };
 

--- a/public/app/js/cbus-ui.js
+++ b/public/app/js/cbus-ui.js
@@ -42,6 +42,7 @@ cbus.ui.displayEpisodes = function(data) {
     );
   }
 
+  // console.log("displayEpisodes", startIndex, endIndex);
   // // old buggy code for removing old date seps
   // let dateSeparatorElems = cbus.ui.homeListElem.getElementsByClassName("list_date-separator");
   // for (let i = 0, l = dateSeparatorElems.length; i < l; i++) {
@@ -122,7 +123,13 @@ cbus.ui.displayEpisodes = function(data) {
       }
     }
   }
-  if (!cbus.ui.applyFilters(cbus.ui.currentFilters)) {
+  // Determine if we should scroll the episodes (retrieving more) if there were more
+  // episodes available than were displayed after applying the filters. Since the episodes
+  // are inserted without removal, often many of them hidden, we set a maximum of 1000 to
+  // avoid excessively slow retrieval. TODO This behaviour should be changed to remove the
+  // oldest added elements to bound the number of those to manage at any time.
+  if (!cbus.ui.applyFilters(cbus.ui.currentFilters) && endIndex < Math.min(1000, cbus.data.episodes.length)) {
+    // console.log("displayEpisodes scrollEpisodes", endIndex, cbus.data.episodes.length);
     cbus.ui.scrollEpisodes();
   }
   else {
@@ -1512,6 +1519,7 @@ document.getElementsByClassName("filters")[0].addEventListener("change", functio
     }
   }
   if (!cbus.ui.applyFilters(cbus.ui.currentFilters)) {
+    // console.log("Filters changed scrollEpisodes");
     cbus.ui.scrollEpisodes();
   }
 });

--- a/public/app/js/cbus-ui.js
+++ b/public/app/js/cbus-ui.js
@@ -69,7 +69,7 @@ cbus.ui.displayEpisodes = function(data) {
         feedTitle: feed.title,
         length: episode.length,
         description: episode.description,
-	id: episode.id,
+        id: episode.id,
         url: episode.url,
         index: i
       });
@@ -131,8 +131,7 @@ cbus.ui.displayEpisodes = function(data) {
   if (!cbus.ui.applyFilters(cbus.ui.currentFilters) && endIndex < Math.min(1000, cbus.data.episodes.length)) {
     // console.log("displayEpisodes scrollEpisodes", endIndex, cbus.data.episodes.length);
     cbus.ui.scrollEpisodes();
-  }
-  else {
+  } else {
     cbus.data.state.loadingNextHomePage = false;
   }
 };
@@ -951,7 +950,7 @@ cbus.broadcast.listen("queueChanged", function(e) {
         image: feed.image,
         isQueueItem: true,
         url: data.url,
-	id: data.id,
+        id: data.id,
         description: data.description
       });
 

--- a/public/app/js/cbus-ui.js
+++ b/public/app/js/cbus-ui.js
@@ -42,6 +42,7 @@ cbus.ui.displayEpisodes = function(data) {
     );
   }
 
+  // console.log("display episodes:", startIndex, endIndex);
   // // old buggy code for removing old date seps
   // let dateSeparatorElems = cbus.ui.homeListElem.getElementsByClassName("list_date-separator");
   // for (let i = 0, l = dateSeparatorElems.length; i < l; i++) {
@@ -614,8 +615,6 @@ cbus.ui.makeFeedElem = function(data, index, isExplore) {
     elem.getElementsByClassName("podcast-detail_episode_description")[0].textContent = descriptionTrimmed;
 
     elem.getElementsByClassName("podcast-detail_episode_button--play")[0].onclick = function() {
-      console.log("Setting the element ", info.id, " url ", info.url);
-      console.log("Element: ", document.querySelector(".audios [data-id='" + info.id + "']"));
       cbus.audio.setElement(document.querySelector(".audios [data-id='" + info.id + "']"));
       cbus.audio.play();
     };
@@ -920,7 +919,7 @@ cbus.broadcast.listen("subscribe-success", e => {
 
 /* listen for queue change */
 cbus.broadcast.listen("queueChanged", function(e) {
-  if (!e.data.fromUI) {
+  if (!e.data || !e.data.fromUI) {
     if (cbus.audio.queue.length === 0) {
       document.body.classList.add("queue-empty");
     } else {
@@ -1481,6 +1480,7 @@ cbus.ui.satisfiesFilters = function(data, filters) {
 
 cbus.ui.applyFilters = function(filters) {
   let listItems = cbus.ui.homeListElem.getElementsByClassName("episode");
+  // console.log("filters", filters, listItems.length);
   for (let i = 0, l = listItems.length; i < l; i++) {
     let elem = listItems[i];
     let data = cbus.data.getEpisodeData({ index: i });

--- a/public/app/js/main.js
+++ b/public/app/js/main.js
@@ -5,10 +5,7 @@ $(document).ready(function() {
 
     if (classList.contains("episode_button")) {
       var id = e.target.parentElement.parentElement.parentElement.dataset.id;
-      console.log("Getting the element using id ", id);
-      console.log("Greatgrandfather element", e.target.parentElement.parentElement.parentElement);
       var audioElem = document.querySelector(".audios [data-id='" + id + "']");
-      console.log("Element: ", audioElem);
 
       if (classList.contains("episode_button--play")) {
         var $episodeElem = $target.closest(".episode");

--- a/public/app/js/main.js
+++ b/public/app/js/main.js
@@ -285,7 +285,7 @@ $(document).ready(function() {
         for (let id of oldList) {
           cbus.broadcast.send("offline_episodes_changed", {
             episodeURL: id, // TODO should be episodeURL
-	    episodeId: id
+            episodeId: id
           });
         }
       } else {
@@ -303,7 +303,7 @@ $(document).ready(function() {
 
             cbus.broadcast.send("offline_episodes_changed", {
               episodeURL: episodeId, // TODO should be episodeURL
-	      episodeId: episodeId
+              episodeId: episodeId
             });
           }
         }

--- a/public/app/js/main.js
+++ b/public/app/js/main.js
@@ -5,7 +5,10 @@ $(document).ready(function() {
 
     if (classList.contains("episode_button")) {
       var id = e.target.parentElement.parentElement.parentElement.dataset.id;
+      console.log("Getting the element using id ", id);
+      console.log("Greatgrandfather element", e.target.parentElement.parentElement.parentElement);
       var audioElem = document.querySelector(".audios [data-id='" + id + "']");
+      console.log("Element: ", audioElem);
 
       if (classList.contains("episode_button--play")) {
         var $episodeElem = $target.closest(".episode");
@@ -218,8 +221,7 @@ $(document).ready(function() {
 
   /* update stream or load from cache */
 
-  var storedEpisodes, lastAudioInfo, lastQueueInfos,
-      lastAudioURL, lastAudioTime;
+  var storedEpisodes, lastAudioInfo, lastQueueInfos, lastAudioId, lastAudioTime;
 
   localforageGetMulti([
     "cbus_feeds_qnp", "cbus_cache_episodes", "cbus_episodes_offline", "cbus_episodes_offline_map",
@@ -243,7 +245,7 @@ $(document).ready(function() {
       lastQueueInfos = r["cbus-last-queue-infos"];
     }
     if (r.hasOwnProperty("cbus-last-audio-url")) {
-      lastAudioURL = r["cbus-last-audio-url"];
+      lastAudioId = r["cbus-last-audio-url"];
     }
     if (r.hasOwnProperty("cbus-last-audio-time")) {
       lastAudioTime = r["cbus-last-audio-time"];
@@ -285,7 +287,8 @@ $(document).ready(function() {
         cbus.data.episodesOfflineMap = {};
         for (let id of oldList) {
           cbus.broadcast.send("offline_episodes_changed", {
-            episodeURL: id
+            episodeURL: id, // TODO should be episodeURL
+	    episodeId: id
           });
         }
       } else {
@@ -294,15 +297,16 @@ $(document).ready(function() {
             filenameOnly: true
           });
           if (files.indexOf(filename) === -1) {
-            let episodeURL = cbus.data.episodesOffline[i];
+            let episodeId = cbus.data.episodesOffline[i];
 
             cbus.data.episodesOffline.splice(i, 1);
-            if (cbus.data.episodesOfflineMap.hasOwnProperty(episodeURL)) {
-              delete cbus.data.episodesOfflineMap[episodeURL];
+            if (cbus.data.episodesOfflineMap.hasOwnProperty(episodeId)) {
+              delete cbus.data.episodesOfflineMap[episodeId];
             }
 
             cbus.broadcast.send("offline_episodes_changed", {
-              episodeURL: episodeURL
+              episodeURL: episodeId, // TODO should be episodeURL
+	      episodeId: episodeId
             });
           }
         }
@@ -313,7 +317,7 @@ $(document).ready(function() {
 
     cbus.data.episodesUnsubbed = []
 
-    if (!storedEpisodes && !lastAudioURL) {
+    if (!storedEpisodes && !lastAudioId) {
       cbus.ui.firstrunContainerElem.classList.add("visible");
     }
 
@@ -338,8 +342,8 @@ $(document).ready(function() {
     cbus.data.updateMedias(); // make audio elems and add to DOM
     cbus.ui.displayEpisodes(); // display the episodes we already have
 
-    if (lastAudioURL) {
-      let elem = document.querySelector(`.audios [data-id='${lastAudioURL}']`);
+    if (lastAudioId) {
+      let elem = document.querySelector(`.audios [data-id='${lastAudioId}']`);
       if (elem) {
         // cbus.audio.setElement(elem, true);
         cbus.audio.setElement(elem);

--- a/public/app/js/main.js
+++ b/public/app/js/main.js
@@ -283,7 +283,7 @@ $(document).ready(function() {
         cbus.data.episodesOffline = [];
         cbus.data.episodesOfflineMap = {};
         for (let id of oldList) {
-          const episodeData = cbus.data.getEpisodeData({ id });
+          const episodeData = cbus.data.getEpisodeData({ id: id });
           cbus.broadcast.send("offline_episodes_changed", {
             episodeURL: episodeData ? episodeData.url : id,
             episodeId: id
@@ -297,12 +297,12 @@ $(document).ready(function() {
           if (files.indexOf(filename) === -1) {
             let episodeId = cbus.data.episodesOffline[i];
 
-            cbus.data.episodesOffline.splice(i, 1);
+            cbus.data.episodesOffline.splice(i, 1); // TODO fix index modification bug
             if (cbus.data.episodesOfflineMap.hasOwnProperty(episodeId)) {
               delete cbus.data.episodesOfflineMap[episodeId];
             }
 
-            const episodeData = cbus.data.getEpisodeData({ id });
+            const episodeData = cbus.data.getEpisodeData({ id: episodeId });
             cbus.broadcast.send("offline_episodes_changed", {
               episodeURL: episodeData ? episodeData.url : episodeId,
               episodeId: episodeId

--- a/public/app/js/main.js
+++ b/public/app/js/main.js
@@ -283,8 +283,9 @@ $(document).ready(function() {
         cbus.data.episodesOffline = [];
         cbus.data.episodesOfflineMap = {};
         for (let id of oldList) {
+          const episodeData = cbus.data.getEpisodeData({ id });
           cbus.broadcast.send("offline_episodes_changed", {
-            episodeURL: id, // TODO should be episodeURL
+            episodeURL: episodeData ? episodeData.url : id,
             episodeId: id
           });
         }
@@ -301,8 +302,9 @@ $(document).ready(function() {
               delete cbus.data.episodesOfflineMap[episodeId];
             }
 
+            const episodeData = cbus.data.getEpisodeData({ id });
             cbus.broadcast.send("offline_episodes_changed", {
-              episodeURL: episodeId, // TODO should be episodeURL
+              episodeURL: episodeData ? episodeData.url : episodeId,
               episodeId: episodeId
             });
           }


### PR DESCRIPTION
- 	Fixed duplicated episodes on sites such as Patreon which emit changing URLs. Now uses the `<guid>` element as an id if it's present in the feed in preference to the URL.
-	Correctly retrieve episode descriptions where an empty `<itunes:description/>` element and a `<description>` element may both exist in the feed.
-	Fixed queue errors [reported](https://github.com/z-------------/CPod/issues/234#issuecomment-924323319) (#234)
-	Fixed bug where the filtered episode lists would end prematurely, and hence unscrollable, if there were less displayable episodes and date separators than the length of the episode list.
-	Update version number to v1.28.1.
