### PR TITLE
Changed URL and processing to match Apple's new Podcast report

### DIFF
--- a/public/app/js/cbus-server-get-popular-podcasts.js
+++ b/public/app/js/cbus-server-get-popular-podcasts.js
@@ -14,7 +14,7 @@ if (!cbus.hasOwnProperty("server")) { cbus.server = {} }
       ) {
         callback(r.cbus_popular_podcasts_cache)
       } else {
-	popularPodcastsURL = `https://rss.applemarketingtools.com/api/v2/${region}/podcasts/top/10/podcast-episodes.json`;
+        const popularPodcastsURL = `https://rss.applemarketingtools.com/api/v2/${region}/podcasts/top/10/podcasts.json`;
         xhr(popularPodcastsURL, function(err, status, r) {
           if (statusCodeNotOK(status.statusCode)) {
             callback(false);
@@ -25,18 +25,20 @@ if (!cbus.hasOwnProperty("server")) { cbus.server = {} }
             var doneCount = 0
 
             for (let i = 0, l = popularPodcasts.length; i < l; i++) {
-              let showInfo = popularPodcasts[i]
-              cbus.server.getPodcastInfo(showInfo.url, function(podcastInfo) {
-                doneCount += 1
-                if (podcastInfo !== null) {
-                  podcastInfo.url = showInfo.url
-                  result.push(podcastInfo)
-                }
-                if (doneCount === popularPodcasts.length) {
-                  callback(result)
-                  localforage.setItem("cbus_popular_podcasts_cache", result)
-                  localforage.setItem("cbus_popular_podcasts_cache_time", new Date().getTime())
-                }
+              xhr("https://itunes.apple.com/lookup?id=" + popularPodcasts[i].id, function(err, status, r) {
+                let showInfo = JSON.parse(r).results[0]
+                cbus.server.getPodcastInfo(showInfo.feedUrl, function(podcastInfo) {
+                  doneCount += 1
+                  if (podcastInfo !== null) {
+                    podcastInfo.url = showInfo.feedUrl
+                    result.push(podcastInfo)
+                  }
+                  if (doneCount === popularPodcasts.length) {
+                    callback(result)
+                    localforage.setItem("cbus_popular_podcasts_cache", result)
+                    localforage.setItem("cbus_popular_podcasts_cache_time", new Date().getTime())
+                  }
+                })
               })
             }
           }

--- a/public/app/js/cbus-server-get-popular-podcasts.js
+++ b/public/app/js/cbus-server-get-popular-podcasts.js
@@ -14,30 +14,29 @@ if (!cbus.hasOwnProperty("server")) { cbus.server = {} }
       ) {
         callback(r.cbus_popular_podcasts_cache)
       } else {
-        xhr(`https://rss.itunes.apple.com/api/v1/${region}/podcasts/top-podcasts/all/10/explicit.json`, function(err, status, r) {
+	popularPodcastsURL = `https://rss.applemarketingtools.com/api/v2/${region}/podcasts/top/10/podcast-episodes.json`;
+        xhr(popularPodcastsURL, function(err, status, r) {
           if (statusCodeNotOK(status.statusCode)) {
             callback(false);
           } else {
             let result = []
 
-            let popularPodcasts = JSON.parse(r).feed.results
+            let popularPodcasts = JSON.parse(r).feed.results;
             var doneCount = 0
 
             for (let i = 0, l = popularPodcasts.length; i < l; i++) {
-              xhr("https://itunes.apple.com/lookup?id=" + popularPodcasts[i].id, function(err, status, r) {
-                let showInfo = JSON.parse(r).results[0]
-                cbus.server.getPodcastInfo(showInfo.feedUrl, function(podcastInfo) {
-                  doneCount += 1
-                  if (podcastInfo !== null) {
-                    podcastInfo.url = showInfo.feedUrl
-                    result.push(podcastInfo)
-                  }
-                  if (doneCount === popularPodcasts.length) {
-                    callback(result)
-                    localforage.setItem("cbus_popular_podcasts_cache", result)
-                    localforage.setItem("cbus_popular_podcasts_cache_time", new Date().getTime())
-                  }
-                })
+              let showInfo = popularPodcasts[i]
+              cbus.server.getPodcastInfo(showInfo.url, function(podcastInfo) {
+                doneCount += 1
+                if (podcastInfo !== null) {
+                  podcastInfo.url = showInfo.url
+                  result.push(podcastInfo)
+                }
+                if (doneCount === popularPodcasts.length) {
+                  callback(result)
+                  localforage.setItem("cbus_popular_podcasts_cache", result)
+                  localforage.setItem("cbus_popular_podcasts_cache_time", new Date().getTime())
+                }
               })
             }
           }


### PR DESCRIPTION
- `https://rss.itunes.apple.com/api/v1/${region}/podcasts/top-podcasts/all/10/explicit.json` no longer works, so changed to the new `applemarketingtools.com` URL and adjusted the interpretation of the results.